### PR TITLE
Working directory error for final decoded file

### DIFF
--- a/deobs.py
+++ b/deobs.py
@@ -590,7 +590,7 @@ class DeobfuScripter(ServiceBase):
                 if extract_file:
                     # Save extracted file
                     byte_count = 500
-                    file_name = f"{request.file_name}_decoded_final"
+                    file_name = f"{os.path.basename(request.file_name)}_decoded_final"
                     file_path = os.path.join(self.working_directory, file_name)
                     with open(file_path, 'wb+') as f:
                         f.write(clean)


### PR DESCRIPTION
request.file_name is sometimes a path which combines with the working directory
to make a non-existant path. Using os.path.basename insures that the file name
won't interfere with the working directory.