### PR TITLE
Prevent teams links from showing up as deobfuscated when they aren't

### DIFF
--- a/deobs.py
+++ b/deobs.py
@@ -585,7 +585,7 @@ class DeobfuScripter(ServiceBase):
                 for ioc_type, iocs in pat_values.items():
                     for ioc in iocs:
                         if ioc_type == 'network.static.uri' \
-                                and ioc.split(b'?', 1)[0] not in request.file_contents:
+                                and ioc.split(b'?', 1)[0].split(b'_meeting') not in request.file_contents:
                             diff_tags.setdefault(ioc_type, [])
                             diff_tags[ioc_type].append(ioc)
                         elif ioc not in request.file_contents:


### PR DESCRIPTION
There's a base64 section after the _meeting in the url that makes deobfuscripter think its a new url