### PR TITLE
Fix powershell caret regex

### DIFF
--- a/deobs.py
+++ b/deobs.py
@@ -295,7 +295,7 @@ class DeobfuScripter(ServiceBase):
         try:
             if b"^" in text or b"`" in text:
                 output = text
-                for full in regex.findall(rb'"[^"]+[A-Za-z0-9]+(\^|`)+[A-Za-z0-9]+[^"]+"', text):
+                for full in regex.findall(rb'"[^"]+[A-Za-z0-9](\^|`)+[A-Za-z0-9][^"]+"', text):
                     if isinstance(full, tuple):
                         full = full[0]
                     char_to_be_removed = b"^" if b"^" in full else b"`"
@@ -547,8 +547,7 @@ class DeobfuScripter(ServiceBase):
             with ThreadPoolExecutor() as executor:
                 threads = [executor.submit(technique, layer) for name, technique in techniques]
                 results = [thread.result() for thread in threads]
-                for i in range(len(results)):
-                    result = results[i]
+                for i, result in enumerate(results):
                     if result:
                         layers_list.append((techniques[i][0], result))
                         # Looks like it worked, restart with new layer


### PR DESCRIPTION
fixes #21 

The redundant + cause excessive backtracking on some files and are
unnecessary since [^"] contains all those characters already.

the pyre2 library is another option to avoid situations like this,
but after fixing the regex the performance was comparable.