### PR TITLE
Multidecoder

### DIFF
--- a/deobs.py
+++ b/deobs.py
@@ -159,15 +159,6 @@ class DeobfuScripter(ServiceBase):
         return None
 
     @staticmethod
-    def concat_strings(text: bytes) -> Optional[bytes]:
-        """ Concatenate disconnected strings """
-        # Line continuation character in VB -- '_'
-        output = regex.sub(rb'[\'"][\s\n_]*?[+&][\s\n_]*[\'"]', b'', text)
-        if output != text:
-            return output
-        return None
-
-    @staticmethod
     def str_reverse(text: bytes) -> Optional[bytes]:
         """ Replace StrReverse function calls with the reverse of its argument """
         output = text
@@ -394,7 +385,6 @@ class DeobfuScripter(ServiceBase):
             ('Simple XOR function', self.simple_xor_function),
         ]
         second_pass: TechniqueList = [
-            ('Concat strings', self.concat_strings),
             ('MSWord macro vars', self.mswordmacro_vars),
             ('Powershell vars', self.powershell_vars),
             ('Charcode hex', self.charcode_hex),

--- a/deobs.py
+++ b/deobs.py
@@ -115,7 +115,6 @@ class DeobfuScripter(ServiceBase):
             output = output.replace(escape, int(escape[2:-1]).to_bytes(1, 'big'))
         return output if output != text else None
 
-
     @staticmethod
     def vars_of_fake_arrays(text: bytes) -> Optional[bytes]:
         """ Parse variables of fake arrays """
@@ -156,19 +155,6 @@ class DeobfuScripter(ServiceBase):
         except Exception as e:
             self.log.warning(f"Technique array_of_strings failed with error: {str(e)}")
 
-        return None
-
-    @staticmethod
-    def str_reverse(text: bytes) -> Optional[bytes]:
-        """ Replace StrReverse function calls with the reverse of its argument """
-        output = text
-        # VBA format StrReverse("[text]")
-        replacements = regex.findall(rb'(StrReverse\("(.+?(?="\))))', output)
-        for full, string in replacements:
-            reversed_string = full.replace(string, string[::-1]).replace(b"StrReverse(", b"")[:-1]
-            output = output.replace(full, reversed_string)
-        if output != text:
-            return output
         return None
 
     @staticmethod
@@ -381,7 +367,6 @@ class DeobfuScripter(ServiceBase):
             ('Powershell carets', self.powershell_carets),
             ('Array of strings', self.array_of_strings),
             ('Fake array vars', self.vars_of_fake_arrays),
-            ('Reverse strings', self.str_reverse),
             ('Simple XOR function', self.simple_xor_function),
         ]
         second_pass: TechniqueList = [

--- a/deobs.py
+++ b/deobs.py
@@ -395,6 +395,8 @@ class DeobfuScripter(ServiceBase):
                 layer = b"\n".join(extracted_parts).strip()
                 extract_res.add_line(name)
                 break
+        if len(layer.strip()) < 2:
+            return  # No script present in file
         if request.file_type == 'code/ps1':
             sig = regex.search(
                 rb'# SIG # Begin signature block\r\n(?:# [A-Za-z0-9+/=]+\r\n)+# SIG # End signature block',

--- a/deobs.py
+++ b/deobs.py
@@ -26,7 +26,6 @@ TechniqueList = List[Tuple[str, Callable[[bytes], Optional[bytes]]]]
 
 class DeobfuScripter(ServiceBase):
     """ Service for deobfuscating scripts """
-    FILETYPES = ['application', 'document', 'exec', 'image', 'Microsoft', 'text']
     VALIDCHARS = b' 0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~'
     BINCHARS = bytes(list(set(range(0, 256)) - set(VALIDCHARS)))
 
@@ -102,20 +101,6 @@ class DeobfuScripter(ServiceBase):
                     final_dec = regex.sub(b'[\x00]*$', b'', decoded)
                     output = output.replace(hex_char, final_dec)
 
-        if output == text:
-            return None
-        return output
-
-    @staticmethod
-    def chr_decode(text: bytes) -> Optional[bytes]:
-        """ Replace calls to chr with the corresponding character """
-        output = text
-        for fullc, c in regex.findall(rb'(chr[bw]?\(([0-9]{1,3})\))', output, regex.I):
-            # noinspection PyBroadException
-            try:
-                output = regex.sub(regex.escape(fullc), '"{}"'.format(chr(int(c))).encode('utf-8'), output)
-            except Exception:
-                continue
         if output == text:
             return None
         return output
@@ -435,7 +420,6 @@ class DeobfuScripter(ServiceBase):
         # --- Prepare Techniques ----------------------------------------------------------------------------------
         first_pass: TechniqueList = [
             ('MSOffice Embedded script', self.msoffice_embedded_script_string),
-            ('CHR and CHRB decode', self.chr_decode),
             ('String replace', self.string_replace),
             ('Powershell carets', self.powershell_carets),
             ('Array of strings', self.array_of_strings),

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -23,29 +23,35 @@ submission_params:
     value: false
 
 heuristics:
-  - description: Obfuscation techniques were found and deobfuscated in the file
+  - description: Obfuscation techniques were found and de-obfuscated in the file
     filetype: code/.*
     heur_id: 1
     name: Obfuscation
     score: 10
     max_score: 1000
 
-  - description: IOCs where found only after de-obfuscation
+  - description: IOCs were found after simple de-obfuscation
+    filetype: code/.*
+    heur_id: 5
+    name: Lightly De-obfuscated IOCs
+    score: 50
+
+  - description: IOCs were found only after layered de-obfuscations
     filetype: code/.*
     heur_id: 6
     name: De-obfuscated IOCs
-    score: 50
+    score: 100
 
-  - description: Network IOCs where found only after de-obfuscation
+  - description: Network IOCs were found only after layered de-obfuscations
     filetype: code/.*
     heur_id: 7
     name: De-obfuscated Network IOCs
     score: 500
 
-  - description: The service found interesting files during the deobfuscation
+  - description: The service found interesting files during the de-obfuscation
     filetype: code/.*
     heur_id: 8
-    name: Deobfuscated file
+    name: De-obfuscated file
     score: 10
 
 docker_config:


### PR DESCRIPTION
New version of DeobfuScripter integrating Multidecoder and using it's wrapper in assemblyline_v4_service.
Multidecoder is run with depth 1 on each pass and IOCs are displayed sorted per pass.
Several de-obfucations are moved to Multidecoder.
Scoring on the number of de-obfuscations is simplified into a single heuristic, and code extracts are separated from de-obfuscations for scoring. 
