### PR TITLE
Refactoring charcodes

### DIFF
--- a/deobs.py
+++ b/deobs.py
@@ -100,7 +100,7 @@ class DeobfuScripter(ServiceBase):
         for fullc, c in regex.findall(rb'(chr[bw]?\(([0-9]{1,3})\))', output, regex.I):
             # noinspection PyBroadException
             try:
-                output = regex.sub(regex.escape(fullc), '"{}"'.format(chr(int(c))).encode('utf-8'), output)
+                output = regex.sub(regex.escape(fullc), f'"{chr(int(c))}"'.encode('utf-8'), output)
             except Exception:
                 continue
         if output == text:


### PR DESCRIPTION
- removing charcode functionality since it mangles files
- todo: add decimal charcode decoding to charcode function (currently empty)
- renamed xml_escape to charcode_xml to reflect similarity with charcode methods
- refactored charcode methods to use regex.sub instead of regex.findall + bytes.sub
- seperated unicode charcodes from hexadecimal charcodes
- simplified charcode methods by enforcing correct charcode lengths and better regexes
- made charcode_xml more flexible to reflect what xml and html parsers allow.