### PR TITLE
Removing redundant start debug

### DIFF
--- a/deobs.py
+++ b/deobs.py
@@ -34,9 +34,6 @@ class DeobfuScripter(ServiceBase):
         self.hashes: Set[str] = set()
         self.files_extracted: Set[str] = set()
 
-    def start(self) -> None:
-        self.log.debug("DeobfuScripter service started")
-
     # --- Support Modules ----------------------------------------------------------------------------------------------
 
     def printable_ratio(self, text: bytes) -> float:


### PR DESCRIPTION
ServiceBase.start_service already logs the service starting