### PR TITLE
Fix multidecoder version >=1.6.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ lxml
 regex
 # assemblyline-service-utilities also depends on multidecoder and pins the version number.
 # Make sure the version ranges are compatible when upgrading.
-multidecoder>=1.3.1,<2.0
+multidecoder>=1.6.2,<2.0
 assemblyline-service-utilities>=4.5,<4.6


### PR DESCRIPTION
1.6.2 fixes an base64 decoding error that causes issues for deobfuscripter.