### PR TITLE
Multidecoder v1.6.2 still has the base64 bug on some inputs, pinning …

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ lxml
 regex
 # assemblyline-service-utilities also depends on multidecoder and pins the version number.
 # Make sure the version ranges are compatible when upgrading.
-multidecoder>=1.6.2,<2.0
+multidecoder>=1.6.3,<2.0
 assemblyline-service-utilities>=4.5,<4.6


### PR DESCRIPTION
…to v1.6.3