### PR TITLE
Pin multidecoder version >1.6.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ lxml
 regex
 # assemblyline-service-utilities also depends on multidecoder and pins the version number.
 # Make sure the version ranges are compatible when upgrading.
-multidecoder>=1.6.3,<2.0
+multidecoder>=1.6.12,<2.0
 assemblyline-service-utilities>=4.5,<4.6


### PR DESCRIPTION
Multidecoder versions 1.6.6 through 1.6.11 have a regex performance bug. See https://github.com/CybercentreCanada/Multidecoder/pull/126