### PR TITLE
Pin dependencies in tests/requirements.txt

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
-assemblyline
-assemblyline-service-utilities
+assemblyline==4.7.4.4
+assemblyline-service-utilities==4.6.1.2
+multidecoder==1.6.27
 pytest


### PR DESCRIPTION
Certain dependencies can change the service output without any issue existing in the deobfuscripter service itself, particularly those involved in tagging.  Pinning:
- assemblyline (identify)
- multidecoder (tagging and deobfuscations)
- assemblyline-service-utilities (tagging) to the versions used to generate the tests for consistency. They should be updated to the current version whenever the tests are regenerated.